### PR TITLE
Update blacklisted-sender-strings.map

### DIFF
--- a/lists/blacklisted-sender-strings.map
+++ b/lists/blacklisted-sender-strings.map
@@ -74,3 +74,4 @@
 /customhkaman/i
 /potaari.cam/i
 /lastminuteloan/i
+/dissidentnetwork.com/i


### PR DESCRIPTION
This is one that rspamd block list does not stop (using "@email,dissidentnetwork.com")
spammer that does not allow unsubscribes and changes sender address with each send so will not go to junk -
example of today's send address: Patriot.bwlghekvuagitziftmho@email.dissidentnetwork.com

Abuse report filed with their domain name host, GoDaddy