### PR TITLE
Drop sailthru.com from blacklisted-sender-strings.map

### DIFF
--- a/lists/blacklisted-sender-strings.map
+++ b/lists/blacklisted-sender-strings.map
@@ -33,7 +33,7 @@
 /matthew\.larweh/i
 /bellmedia-ctv/i
 /yutikanatural\.com/i
-/(sentinbox\.com|yourhealthylife\.io|biotrustnews\.com|maropost\.com|sailthru\.com|thegreatcourses\.com|kalymnas\.work)/i
+/(sentinbox\.com|yourhealthylife\.io|biotrustnews\.com|maropost\.com|thegreatcourses\.com|kalymnas\.work)/i
 /deli-hemp-news\.com/i
 /revisilpro\.us/i
 /xtremesuccesstechnology/i


### PR DESCRIPTION
Company Rohlik.cz (online supermarket) [1] is using sailthru.com [2]
for sending emails to my mailbox (order confirmation, delayed order, etc.).

[1] https://www.rohlik.cz/
[2] https://www.sailthru.com/

Solves hopefully: Ticket #424566

